### PR TITLE
Fix memory unit conversion in Kubernetes utils

### DIFF
--- a/src/utils/kubernetes/kubernetes-utils.js
+++ b/src/utils/kubernetes/kubernetes-utils.js
@@ -25,17 +25,17 @@ export function parseMemory(memStr) {
   if (Number.isNaN(Number(units))) {
     switch (units) {
       case "Ki":
-        return base * 1000;
-      case "K":
         return base * 1024;
+      case "K":
+        return base * 1000;
       case "Mi":
-        return base * 1000000;
-      case "M":
         return base * 1024 * 1024;
+      case "M":
+        return base * 1000 * 1000;
       case "Gi":
-        return base * 1000000000;
-      case "G":
         return base * 1024 * 1024 * 1024;
+      case "G":
+        return base * 1000 * 1000 * 1000;
       default:
         return base;
     }


### PR DESCRIPTION
## Summary
- correct memory unit conversions when parsing kubernetes stats

## Testing
- `npm test --silent` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68400a687960832eba47145ab085ac64